### PR TITLE
Fix/nzxt cam installation

### DIFF
--- a/nzxt-cam/nzxt-cam.nuspec
+++ b/nzxt-cam/nzxt-cam.nuspec
@@ -6,18 +6,18 @@
 		<title>CAM</title>
 		<authors>NZXT</authors>
 		<owners>MarcioC</owners>
-		<licenseUrl>https://camwebapp.com/terms-of-service</licenseUrl>
-		<projectUrl>https://camwebapp.com/</projectUrl>
+		<licenseUrl>https://nzxt.com/legal/terms-of-service</licenseUrl>
+		<projectUrl>https://nzxt.com/software/cam</projectUrl>
 		<iconUrl>https://raw.githubusercontent.com/CruzMarcio/au-packages/master/nzxt-cam/nzxt-cam.png</iconUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<description>A COMPLETE PC MONITORING SOLUTION
 The days of using multiple programs to monitor and tune your PC are over. CAM is easy-to-use and comprehensive, providing you the essential data you need to keep your PC running optimally. Think of CAM as your PC's best friend.</description>
 		<summary>PC Monitoring</summary>
 		<releaseNotes>https://blog.nzxt.com/cam-changelog/</releaseNotes>
-		<copyright>NZXT 2018. All Rights Reserved.</copyright>
+		<copyright>NZXT 2024. All Rights Reserved.</copyright>
 		<tags>pc monitoring temperature cooler fan watercooler nzxt</tags>
-		<mailingListUrl>https://support.camwebapp.com/</mailingListUrl>
-		<bugTrackerUrl>https://support.camwebapp.com/</bugTrackerUrl>
+		<mailingListUrl>https://support.nzxt.com/hc/en-us/sections/360005303053-NZXT-CAM</mailingListUrl>
+		<bugTrackerUrl>https://support.nzxt.com/hc/en-us/sections/360005303053-NZXT-CAM</bugTrackerUrl>
 		<packageSourceUrl>https://github.com/CruzMarcio/au-packages/tree/master/nzxt-cam</packageSourceUrl>
 		<dependencies>
 			<dependency id="vcredist2015" version="14.0.24215.20170201" />

--- a/nzxt-cam/tools/chocolateyInstall.ps1
+++ b/nzxt-cam/tools/chocolateyInstall.ps1
@@ -4,7 +4,7 @@ $packageArgs = @{
     packageName    = $env:ChocolateyPackageName
     unzipLocation  = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
     fileType       = 'exe'
-    url            = 'https://camwebapp.com/download/cam'
+    url            = 'https://nzxt-app.nzxt.com/NZXT-CAM-Setup.exe'
 
     softwareName   = 'CAM'
 

--- a/nzxt-cam/tools/chocolateyInstall.ps1
+++ b/nzxt-cam/tools/chocolateyInstall.ps1
@@ -8,7 +8,7 @@ $packageArgs = @{
 
     softwareName   = 'CAM'
 
-    checksum       = '583606fe8e078a9a207c0724aa5cc57c5c620e9831401d5fd1648dd6d08ea6ff'
+    checksum       = '47c83ac3471b06f61aa938f66d26a578fe6996910bb2ecfb825823a8d92cadb7'
     checksumType   = 'sha256'
 
     silentArgs     = "/exelang 1033 /quiet"


### PR DESCRIPTION
Current choco package fails due to a legacy installation location:

![image](https://github.com/user-attachments/assets/9fc84b33-3c62-403f-9a62-fca116b1c460)

> Attempt to get headers for https://camwebapp.com/download/cam failed.
>   The remote file either doesn't exist, is unauthorized, or is forbidden for url 'https://camwebapp.com/download/cam'. Exception calling "GetResponse" with "0" argument(s): "Unable to connect to the remote server"
> Downloading nzxt-cam
>   from 'https://camwebapp.com/download/cam'
> ERROR: The remote file either doesn't exist, is unauthorized, or is forbidden for url 'https://camwebapp.com/download/cam'. Exception calling "GetResponse" with "0" argument(s): "Unable to connect to the remote server"
> This package is likely not broken for licensed users - see https://docs.chocolatey.org/en-us/features/private-cdn.
> The install of nzxt-cam was NOT successful.
> Error while running 'C:\ProgramData\chocolatey\lib\nzxt-cam\tools\chocolateyInstall.ps1'.
>  See log for details.

Updated installation location to: `https://nzxt-app.nzxt.com/NZXT-CAM-Setup.exe` with matching SHA256